### PR TITLE
Ucspec addition

### DIFF
--- a/v1.0.1/ListSample.c
+++ b/v1.0.1/ListSample.c
@@ -1,0 +1,128 @@
+#include "ListSample.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct __item_struct __item_t;
+
+// Details of __list_struct and __item_struct are private
+struct __item_struct
+{
+    void* data;
+    __item_t *next;
+};
+
+struct __list_struct
+{
+    int size;
+    int elem_size;
+    __item_t header;
+};
+
+// Creates a new list and returns its address
+list_t* list_create(unsigned int element_size)
+{
+    list_t *list = malloc(sizeof(list_t));
+    list->elem_size = element_size;
+    list->size = 0;
+    list->header.next = NULL;
+
+    return list;
+}
+
+// Gibt die Anzahl der Element der Liste zurück
+int list_size(list_t *list)
+{
+    return list->size;
+}
+
+// Fügt ein Element an einer bestimmten Stelle ein
+int list_insert(list_t *list,void *element,int index)
+{
+    int i;
+    __item_t *new_item;
+    __item_t *current_item = &list->header;
+
+    if (index > list->size || index < 0) return -1;
+    for (i = 0; i < index; i++)
+    {
+        current_item = current_item->next;
+    }
+    new_item = malloc(sizeof(__item_t));
+    new_item->next = current_item->next;
+    new_item->data = malloc(list->elem_size);
+    current_item->next = new_item;
+    memcpy(new_item->data, element, list->elem_size);
+    list->size++;
+    return EXIT_SUCCESS;
+}
+// Sucht nach dem erstem, gleichem Element und gibt
+// dessen Position zurück
+int list_index(list_t *list, void *element)
+{
+
+    int i;
+    __item_t *current_item = list->header.next;
+
+    for (i = 0; current_item != NULL; i++)
+    {
+
+        if(0 == memcmp(element,current_item->data,list->size)) return i;
+        current_item = current_item->next;
+    }
+
+    return -1;
+}
+// Kopiert den Wert nach element.
+int list_get(list_t *list, void* element, int index)
+{
+    int i;
+    __item_t *current_item = list->header.next;
+    if (index > list->size || index < 0) return -1;
+    for (i=0; i < index; i++)
+    {
+        current_item = current_item->next;
+    }
+
+    memcpy(element,current_item->data,list->elem_size);
+
+
+    return EXIT_SUCCESS;
+}
+// Wie get, löscht das Element jedoch aus der Liste.
+int list_rem(list_t *list, void* element, int index)
+{
+    int i;
+    __item_t *current_item = &list->header;
+    __item_t *deadman;
+    if (index > list->size || index < 0) return -1;
+    for (i=0; i < index; i++)
+    {
+        current_item = current_item->next;
+    }
+
+    memcpy(element,current_item->next->data,list->elem_size);
+    deadman = current_item->next;
+    current_item->next = deadman->next;
+    free(deadman->data);
+    free(deadman);
+    list->size--;
+
+    return EXIT_SUCCESS;
+}
+// löscht die gesamte Liste und gibt den Speicher frei
+int list_destroy(list_t **list)
+{
+    __item_t* current = (*list)->header.next;
+    while(current != 0) {
+        __item_t* next = current->next;
+        current->data = 0;
+        current->next = 0;
+        free(current);
+        current = next;
+    }
+    free(*list);
+    *list = 0;
+
+    return EXIT_SUCCESS;
+}

--- a/v1.0.1/ListSample.h
+++ b/v1.0.1/ListSample.h
@@ -1,0 +1,15 @@
+#ifndef LISTSAMPLE_H
+#define LISTSAMPLE_H
+
+typedef struct __list_struct list_t;
+
+list_t* list_create(unsigned int element_size);
+int list_init(list_t *list, unsigned int element_size);
+int list_size(list_t* list);
+int list_insert(list_t *list,void *element,int index);
+int list_index(list_t *list, void *element);
+int list_get(list_t *list, void* element, int index);
+int list_rem(list_t *list, void* element, int index);
+int list_destroy(list_t** list);
+
+#endif // LISTSAMPLE_H

--- a/v1.0.1/ListSampleSpec.c
+++ b/v1.0.1/ListSampleSpec.c
@@ -8,147 +8,147 @@
 
 static void Specifications(void)
 {
-  DESCRIBE("list_create(sizeof(int))")
+    DESCRIBE("list_create(sizeof(int))")
 
-    list_t* l = list_create(sizeof(int));
+        list_t* l = list_create(sizeof(int));
 
-    IT("should not return NULL")
-      SHOULD_NOT_BE_NULL(l);
-    IT_END
+        IT("should not return NULL")
+            SHOULD_NOT_BE_NULL(l);
+        IT_END
 
-    IT("should create an empty list")
-      SHOULD_EQ(0, list_size(l));
-    IT_END
+        IT("should create an empty list")
+            SHOULD_EQ(0, list_size(l));
+        IT_END
 
-    IT("should return an error when out of memory") IT_END
+        IT("should return an error when out of memory") IT_END
 
-    list_destroy(&l);
+        list_destroy(&l);
 
-  DESCRIBE_END
+    DESCRIBE_END
 
-  DESCRIBE("list_insert(list*, element*, index)")
+    DESCRIBE("list_insert(list*, element*, index)")
 
-    IT("should increment list size when inserting an element")
-      list_t* l = list_create(sizeof(int));
-      int element = 25;
-      list_insert(l, &element, 0);
-      SHOULD_EQ(1, list_size(l)+1); // provoke failure
-      list_destroy(&l);
-    IT_END
+        IT("should increment list size when inserting an element")
+            list_t* l = list_create(sizeof(int));
+            int element = 25;
+            list_insert(l, &element, 0);
+            SHOULD_EQ(1, list_size(l)+1); // provoke failure
+            list_destroy(&l);
+        IT_END
 
-    IT("should be able to insert an element before another")
-      int before = 7;
-      int another = 8;
-      list_t* l = list_create(sizeof(int));
-      list_insert(l, &another, 0);
-      list_insert(l, &before, 0);
-      SHOULD_EQ(0, list_index(l, &before));
-      list_destroy(&l);
-    IT_END
+        IT("should be able to insert an element before another")
+            int before = 7;
+            int another = 8;
+            list_t* l = list_create(sizeof(int));
+            list_insert(l, &another, 0);
+            list_insert(l, &before, 0);
+            SHOULD_EQ(0, list_index(l, &before));
+            list_destroy(&l);
+        IT_END
 
-    IT("should return an error when passed an invalid positive index")
-      int element = 5;
-      list_t* l = list_create(sizeof(int));
-      SHOULD_EQ(-1, list_insert(l, &element, 1));
-      list_destroy(&l);
-    IT_END
+        IT("should return an error when passed an invalid positive index")
+            int element = 5;
+            list_t* l = list_create(sizeof(int));
+            SHOULD_EQ(-1, list_insert(l, &element, 1));
+            list_destroy(&l);
+        IT_END
 
-    IT("should return an error when passed a negative index")
-      int element = 5;
-      list_t* l = list_create(sizeof(int));
-      SHOULD_EQ(-1, list_insert(l, &element, -1));
-      list_destroy(&l);
-    IT_END
+        IT("should return an error when passed a negative index")
+            int element = 5;
+            list_t* l = list_create(sizeof(int));
+            SHOULD_EQ(-1, list_insert(l, &element, -1));
+            list_destroy(&l);
+        IT_END
 
-  DESCRIBE_END
+    DESCRIBE_END
 
-  DESCRIBE("list_index(list*, element*)")
+    DESCRIBE("list_index(list*, element*)")
 
-    IT("should be able to find an element")
-      int element = 6;
-      list_t* l = list_create(sizeof(int));
-      list_insert(l, &element, 0);
-      SHOULD_EQ(0, list_index(l, &element));
-      list_destroy(&l);
-    IT_END
+        IT("should be able to find an element")
+            int element = 6;
+            list_t* l = list_create(sizeof(int));
+            list_insert(l, &element, 0);
+            SHOULD_EQ(0, list_index(l, &element));
+            list_destroy(&l);
+        IT_END
 
-    IT("should should return an error for a non-existent element")
-      int elements[] = {4, 5};
-      int non_existent = 7;
-      list_t* l = list_create(sizeof(int));
-      list_insert(l, elements, 0);
-      list_insert(l, elements+1, 1);
-      SHOULD_EQ(-1, list_index(l, &non_existent));
-      list_destroy(&l);
-    IT_END
+        IT("should should return an error for a non-existent element")
+            int elements[] = {4, 5};
+            int non_existent = 7;
+            list_t* l = list_create(sizeof(int));
+            list_insert(l, elements, 0);
+            list_insert(l, elements+1, 1);
+            SHOULD_EQ(-1, list_index(l, &non_existent));
+            list_destroy(&l);
+        IT_END
 
-  DESCRIBE_END
-
-  DESCRIBE("list_get(list*, element*, index)")
-
-    IT("should be able to get an element")
-      int elements[] = {4, 3};
-      int result = 7;
-      list_t* l = list_create(sizeof(int));
-      list_insert(l, elements, 0);
-      list_insert(l, elements + 1, 1);
-      list_get(l, &result, 1);
-      SHOULD_EQ(3, result);
-      list_destroy(&l);
-    IT_END
-
-    IT("should return an error when passed an invalid positive index");
-      int element = 5;
-      list_t* l = list_create(sizeof(int));
-      SHOULD_EQ(-1, list_get(l, &element, 1));
-      list_destroy(&l);
-    IT_END;
-
-    IT("should return an error when passed a negative index")
-      int element = 5;
-      list_t* l = list_create(sizeof(int));
-      SHOULD_EQ(-1, list_get(l, &element, -1));
-      list_destroy(&l);
-    IT_END
-
-  DESCRIBE_END
-
-  DESCRIBE("list_rem(list*, element*, index)")
-
-    IT("should be able to remove an element")
-      int elements[] = {4, 3};
-      int result;
-      list_t* l = list_create(sizeof(int));
-      list_insert(l, elements, 0);
-      list_insert(l, elements + 1, 1);
-      list_rem(l, &result, 1);
-      SHOULD_EQ(3, result);
-      SHOULD_EQ(1, list_size(l));
-      list_destroy(&l);
-    IT_END
-
-    IT("should return an error when passed a negative index")
-      int element = 5;
-      list_t* l = list_create(sizeof(int));
-      SHOULD_EQ(-1, list_rem(l, &element, -1));
-      list_destroy(&l);
-    IT_END
-
-    IT("should return an error when passed an invalid positive index")
-      int element = 5;
-      list_t* l = list_create(sizeof(int));
-      SHOULD_EQ(-1, list_rem(l, &element, 1));
-      list_destroy(&l);
-    IT_END
-
-  DESCRIBE_END
+    DESCRIBE_END
+   
+    DESCRIBE("list_get(list*, element*, index)")
+   
+      IT("should be able to get an element")
+        int elements[] = {4, 3};
+        int result = 7;
+        list_t* l = list_create(sizeof(int));
+        list_insert(l, elements, 0);
+        list_insert(l, elements + 1, 1);
+        list_get(l, &result, 1);
+        SHOULD_EQ(3, result);
+        list_destroy(&l);
+      IT_END
+   
+      IT("should return an error when passed an invalid positive index");
+        int element = 5;
+        list_t* l = list_create(sizeof(int));
+        SHOULD_EQ(-1, list_get(l, &element, 1));
+        list_destroy(&l);
+      IT_END;
+   
+      IT("should return an error when passed a negative index")
+        int element = 5;
+        list_t* l = list_create(sizeof(int));
+        SHOULD_EQ(-1, list_get(l, &element, -1));
+        list_destroy(&l);
+      IT_END
+   
+    DESCRIBE_END
+   
+    DESCRIBE("list_rem(list*, element*, index)")
+   
+        IT("should be able to remove an element")
+            int elements[] = {4, 3};
+            int result;
+            list_t* l = list_create(sizeof(int));
+            list_insert(l, elements, 0);
+            list_insert(l, elements + 1, 1);
+            list_rem(l, &result, 1);
+            SHOULD_EQ(3, result);
+            SHOULD_EQ(1, list_size(l));
+            list_destroy(&l);
+        IT_END
+      
+        IT("should return an error when passed a negative index")
+            int element = 5;
+            list_t* l = list_create(sizeof(int));
+            SHOULD_EQ(-1, list_rem(l, &element, -1));
+            list_destroy(&l);
+        IT_END
+      
+        IT("should return an error when passed an invalid positive index")
+            int element = 5;
+            list_t* l = list_create(sizeof(int));
+            SHOULD_EQ(-1, list_rem(l, &element, 1));
+            list_destroy(&l);
+        IT_END
+      
+    DESCRIBE_END
 }
 
 void Testsuite_List(void)
 {
-  UCSPEC_UseStaticsAtLeastOnce();
-  Specifications();
-  UCSPEC_WriteSummary();
+    UCSPEC_UseStaticsAtLeastOnce();
+    Specifications();
+    UCSPEC_WriteSummary();
 }
 
 int main(void)

--- a/v1.0.1/ListSampleSpec.c
+++ b/v1.0.1/ListSampleSpec.c
@@ -1,0 +1,162 @@
+#include "System.h"
+
+//#define UCUNIT_MODE_SILENT
+
+#include "uCUnit-v1.0.h"
+#include "uCSpec-v1.0.h"
+#include "ListSample.h"
+
+static void Specifications(void)
+{
+  DESCRIBE("list_create(sizeof(int))")
+
+    list_t* l = list_create(sizeof(int));
+
+    IT("should not return NULL")
+      SHOULD_NOT_BE_NULL(l);
+    IT_END
+
+    IT("should create an empty list")
+      SHOULD_EQ(0, list_size(l));
+    IT_END
+
+    IT("should return an error when out of memory") IT_END
+
+    list_destroy(&l);
+
+  DESCRIBE_END
+
+  DESCRIBE("list_insert(list*, element*, index)")
+
+    IT("should increment list size when inserting an element")
+      list_t* l = list_create(sizeof(int));
+      int element = 25;
+      list_insert(l, &element, 0);
+      SHOULD_EQ(1, list_size(l)+1); // provoke failure
+      list_destroy(&l);
+    IT_END
+
+    IT("should be able to insert an element before another")
+      int before = 7;
+      int another = 8;
+      list_t* l = list_create(sizeof(int));
+      list_insert(l, &another, 0);
+      list_insert(l, &before, 0);
+      SHOULD_EQ(0, list_index(l, &before));
+      list_destroy(&l);
+    IT_END
+
+    IT("should return an error when passed an invalid positive index")
+      int element = 5;
+      list_t* l = list_create(sizeof(int));
+      SHOULD_EQ(-1, list_insert(l, &element, 1));
+      list_destroy(&l);
+    IT_END
+
+    IT("should return an error when passed a negative index")
+      int element = 5;
+      list_t* l = list_create(sizeof(int));
+      SHOULD_EQ(-1, list_insert(l, &element, -1));
+      list_destroy(&l);
+    IT_END
+
+  DESCRIBE_END
+
+  DESCRIBE("list_index(list*, element*)")
+
+    IT("should be able to find an element")
+      int element = 6;
+      list_t* l = list_create(sizeof(int));
+      list_insert(l, &element, 0);
+      SHOULD_EQ(0, list_index(l, &element));
+      list_destroy(&l);
+    IT_END
+
+    IT("should should return an error for a non-existent element")
+      int elements[] = {4, 5};
+      int non_existent = 7;
+      list_t* l = list_create(sizeof(int));
+      list_insert(l, elements, 0);
+      list_insert(l, elements+1, 1);
+      SHOULD_EQ(-1, list_index(l, &non_existent));
+      list_destroy(&l);
+    IT_END
+
+  DESCRIBE_END
+
+  DESCRIBE("list_get(list*, element*, index)")
+
+    IT("should be able to get an element")
+      int elements[] = {4, 3};
+      int result = 7;
+      list_t* l = list_create(sizeof(int));
+      list_insert(l, elements, 0);
+      list_insert(l, elements + 1, 1);
+      list_get(l, &result, 1);
+      SHOULD_EQ(3, result);
+      list_destroy(&l);
+    IT_END
+
+    IT("should return an error when passed an invalid positive index");
+      int element = 5;
+      list_t* l = list_create(sizeof(int));
+      SHOULD_EQ(-1, list_get(l, &element, 1));
+      list_destroy(&l);
+    IT_END;
+
+    IT("should return an error when passed a negative index")
+      int element = 5;
+      list_t* l = list_create(sizeof(int));
+      SHOULD_EQ(-1, list_get(l, &element, -1));
+      list_destroy(&l);
+    IT_END
+
+  DESCRIBE_END
+
+  DESCRIBE("list_rem(list*, element*, index)")
+
+    IT("should be able to remove an element")
+      int elements[] = {4, 3};
+      int result;
+      list_t* l = list_create(sizeof(int));
+      list_insert(l, elements, 0);
+      list_insert(l, elements + 1, 1);
+      list_rem(l, &result, 1);
+      SHOULD_EQ(3, result);
+      SHOULD_EQ(1, list_size(l));
+      list_destroy(&l);
+    IT_END
+
+    IT("should return an error when passed a negative index")
+      int element = 5;
+      list_t* l = list_create(sizeof(int));
+      SHOULD_EQ(-1, list_rem(l, &element, -1));
+      list_destroy(&l);
+    IT_END
+
+    IT("should return an error when passed an invalid positive index")
+      int element = 5;
+      list_t* l = list_create(sizeof(int));
+      SHOULD_EQ(-1, list_rem(l, &element, 1));
+      list_destroy(&l);
+    IT_END
+
+  DESCRIBE_END
+}
+
+void Testsuite_List(void)
+{
+  Specifications();
+  UCSPEC_WriteSummary();
+}
+
+int main(void)
+{
+    UCUNIT_Init();
+    UCSPEC_UseStaticsAtLeastOnce();
+    UCUNIT_WriteString("\n**************************************\n\n");
+    Testsuite_List();
+    UCUNIT_Shutdown();
+
+    return 0;
+}

--- a/v1.0.1/ListSampleSpec.c
+++ b/v1.0.1/ListSampleSpec.c
@@ -146,6 +146,7 @@ static void Specifications(void)
 
 void Testsuite_List(void)
 {
+  UCSPEC_UseStaticsAtLeastOnce();
   Specifications();
   UCSPEC_WriteSummary();
 }
@@ -153,7 +154,6 @@ void Testsuite_List(void)
 int main(void)
 {
     UCUNIT_Init();
-    UCSPEC_UseStaticsAtLeastOnce();
     UCUNIT_WriteString("\n**************************************\n\n");
     Testsuite_List();
     UCUNIT_Shutdown();

--- a/v1.0.1/Testsuite.c
+++ b/v1.0.1/Testsuite.c
@@ -34,6 +34,7 @@
  * author.
  */
 
+#define UCUNIT_MODE_VERBOSE
 #include "System.h"
 #include "uCUnit-v1.0.h"
 #include "Testsuite.h"

--- a/v1.0.1/template/ucspec/Makefile
+++ b/v1.0.1/template/ucspec/Makefile
@@ -1,0 +1,76 @@
+#
+# Sample Makefile for uCUnit
+#
+
+#----------------------------------------------------
+# Toolchain configuration
+#----------------------------------------------------
+# Compiler
+CC:=gcc
+CFLAGS:=-g
+
+#Linker
+LD:=gcc
+LDFLAGS:=-g
+
+# Simulator/Emulator
+RUN:=
+
+# Clean up
+RM:=rm
+
+# Silencer
+SILENT:=@
+
+#----------------------------------------------------
+# Files
+#----------------------------------------------------
+# Name of target files
+TARGET:=./ListSampleSpec.exe
+
+# Sourcefiles
+SRCS:=           \
+../System.c          \
+../../ListSample.c  \
+../../ListSampleSpec.c \
+
+# Objectfiles
+OBJS:= \
+../System.obj         \
+../../ListSample.obj  \
+../../ListSampleSpec.obj \
+
+#----------------------------------------------------
+# Build all
+#----------------------------------------------------
+all: $(TARGET)
+
+run: $(TARGET)
+	$(SILENT)echo 'Running $(TARGET)...'
+	$(RUN) $(TARGET)
+	
+#----------------------------------------------------
+# Linker stage
+#----------------------------------------------------
+$(TARGET):	$(OBJS)
+	$(SILENT)echo 'Linking...'
+	$(LD) $(LDFLAGS) -o $(notdir $@) $(notdir $(OBJS))
+
+#----------------------------------------------------
+# Compiler
+#----------------------------------------------------
+%.obj: %.c
+	$(SILENT)echo 'Compiling...'
+	$(CC) $(CFLAGS) -o $(notdir $@) -c $<
+	
+#----------------------------------------------------
+# Clean Project
+#----------------------------------------------------
+clean:
+	$(SILENT)echo 'Running clean...'
+	$(RM) $(TARGET)
+	$(RM) System.obj
+	$(RM) ListSample.obj
+	$(RM) ListSampleSpec.obj
+	$(SILENT)echo 'Clean finished.'
+	

--- a/v1.0.1/uCSpec-v1.0.h
+++ b/v1.0.1/uCSpec-v1.0.h
@@ -1,0 +1,215 @@
+/*****************************************************************************
+ *                                                                           *
+ *  UcSpec - Support for behavior-driven development (specification by       *
+ *           example) for uCUnit                                             *
+ *                                                                           *
+ *  (C) 2014  Arnd R. Strube                                                 *
+ *            https://www.ucunit.org                                         *
+ *                                                                           *
+ *  File        : uCSpec-v1.0.h                                              *
+ *  Description : Macros to support BDD for Unit-Testing                     *
+ *  Author      : Arnd R. Strube                                             *
+ *  Contact     : www.ucunit.org                                             *
+ *                                                                           *
+ *****************************************************************************/
+
+/*
+ * This file is part of ucUnit.
+ *
+ * You can redistribute and/or modify it under the terms of the
+ * Common Public License as published by IBM Corporation; either
+ * version 1.0 of the License, or (at your option) any later version.
+ *
+ * uCUnit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Common Public License for more details.
+ *
+ * You should have received a copy of the Common Public License
+ * along with uCUnit.
+ *
+ * It may also be available at the following URL:
+ *       http://www.opensource.org/licenses/cpl1.0.txt
+ *
+ * If you cannot obtain a copy of the License, please contact the
+ * author.
+ */
+
+#ifndef UCSPEC_0101_H_
+#define UCSPEC_0101_H_
+
+/*****************************************************************************/
+/* Variables                                                                 */
+/*****************************************************************************/
+
+static int ucspec_testcases_todo = 0; /* Number of specs not yet implemented */
+static int ucunit_line = 0;           /* Used to detect empty specifications */
+
+/*****************************************************************************/
+/* Support behavior-driven development (specification by example             */
+/*****************************************************************************/
+
+/**
+ * @Macro:         DESCRIBE(caption)
+ *
+ * @Description:   Macro to mark the beginning of a set of specifications.
+ *
+ * @Param caption: The object to be described as string.
+ *
+ * @Remarks:       Does not use the UCUNIT prefix, because - well that would
+ *                 kind of spoil it.
+ *
+ */
+#define DESCRIBE(caption)                                           \
+    {                                                               \
+        UCUNIT_WriteString("Describe: " caption "\n");              \
+
+/**
+ * @Macro:       DESCRIBE_END
+ *
+ * @Description: Marks the end of a set of specifications.
+ *
+ * @Remarks:     Does not use the UCUNIT prefix, because - well that would
+ *               kind of spoil it.
+ *
+ */
+#define DESCRIBE_END                                                \
+        UCUNIT_WriteString("\n");                                   \
+    }
+
+/**
+ * @Macro:         IT(caption)
+ *
+ * @Description:   Macro to mark the beginning of a specification in
+ *                 behavior-driven development (BDD).
+ *
+ * @Param caption: The behavior that the object should exhibit as string.
+ *
+ * @Remarks:       Wraps UCUNIT_TestcaseBegin(name)
+ *
+ */
+#define IT(caption)                                                 \
+    {                                                               \
+        ucunit_line = __LINE__;                                     \
+        UCUNIT_WriteString("   " caption);                          \
+        UCUNIT_WriteString(" -- ");                                 \
+        ucunit_testcases_failed_checks = ucunit_checks_failed;
+
+/**
+ * @Macro:       IT_END
+ *
+ * @Description: Macro to mark the end of a specification.
+ *               If no code is specified for the specification, then
+ *               it is automatically treated as NOT IMPLEMENTED.
+ *
+ * @Remarks:     wraps UCUNIT_TestcaseBegin(name)
+ *
+ */
+#define IT_END                                                      \
+        if(ucunit_line + 1 >= __LINE__) {                           \
+            UCUNIT_WriteString(" N O T   I M P L E M E N T E D\n"); \
+            ucspec_testcases_todo++;                                \
+        }                                                           \
+        else if( 0==(ucunit_testcases_failed_checks - ucunit_checks_failed) ) \
+        {                                                           \
+            UCUNIT_WriteString("OK\n");                             \
+            ucunit_testcases_passed++;                              \
+        }                                                           \
+        else                                                        \
+        {                                                           \
+            UCUNIT_WriteString("\n");                               \
+            ucunit_testcases_failed++;                              \
+        }                                                           \
+    }
+
+/*****************************************************************************/
+/* Support for "SHOULD"-style assertions                                     */
+/*****************************************************************************/
+
+#define SHOULD(condition, msg, args) UCUNIT_Check(condition, msg, args)
+#define SHOULD_EQ(expected, actual) UCUNIT_CheckIsEqual(expected, actual)
+#define SHOULD_BE_NULL(pointer) UCUNIT_CheckIsNull(pointer)
+#define SHOULD_NOT_BE_NULL(pointer) UCUNIT_CheckIsNotNull(pointer)
+#define SHOULD_BE_IN_RANGE() UCUNIT_CheckIsInRange(value, lower, upper)
+#define SHOULD_BE_8BIT(value, lower, upper) UCUNIT_CheckIs8Bit(value)
+#define SHOULD_BE_16BIT(value) UCUNIT_CheckIs16Bit(value)
+#define SHOULD_BE_32BIT(value) UCUNIT_CheckIs32Bit(value)
+#define SHOULD_BE_BITSET(value) UCUNIT_CheckIsBitSet(value, bitno)
+#define SHOULD_BE_BITCLEAR(value, bitno) UCUNIT_CheckIsBitClear(value, bitno)
+
+/*****************************************************************************/
+/* Eliminate -Werror for unused static variables                             */
+/*****************************************************************************/
+/**
+ * @Macro:       UCSPEC_UseStaticsAtLeastOnce()
+ *
+ * @Description: Silences "defined but not used"-Warnings.
+ *
+ * @Remarks:     This is really a hack - any better ideas?
+ *
+ */
+#define UCSPEC_UseStaticsAtLeastOnce()                                \
+    (void)ucunit_checks_failed;                                       \
+    (void)ucunit_checks_passed;                                       \
+    (void)ucunit_testcases_failed;                                    \
+    (void)ucunit_testcases_passed;                                    \
+    (void)ucunit_testcases_failed_checks;                             \
+    (void)ucunit_checklist_failed_checks;                             \
+    (void)ucunit_action;                                              \
+    (void)ucunit_checkpoints;                                         \
+    (void)ucunit_index;
+
+/*****************************************************************************/
+/* uCSpec Replacement Macros                                                 */
+/*****************************************************************************/
+
+/**
+ * @Macro:       uCSpec replacement for UCUNIT_WriteFailedMsg(msg, args)
+ *
+ * @Description: Writes a message that check has failed.
+ *
+ * @Param msg:   Message to write. This is the name of the called
+ *               Check, without the substring UCUNIT_Check.
+ * @Param args:  Argument list as string.
+ *
+ * @Remarks:     This has been slightly adjusted to fit the specification
+ *               output format.
+ *
+ */
+#undef  UCUNIT_WriteFailedMsg
+#ifdef  UCUNIT_MODE_SILENT
+#define UCUNIT_WriteFailedMsg(msg, args)                            \
+    UCUNIT_WriteString(" F A I L E D");
+#else
+#define UCUNIT_WriteFailedMsg(msg, args)                            \
+    UCUNIT_WriteString(" F A I L E D :\n");                         \
+    UCUNIT_WriteString("        " __FILE__);                        \
+    UCUNIT_WriteString(":");                                        \
+    UCUNIT_WriteString(UCUNIT_DefineToString(__LINE__));            \
+    UCUNIT_WriteString(": failed:");                                \
+    UCUNIT_WriteString(msg);                                        \
+    UCUNIT_WriteString("(");                                        \
+    UCUNIT_WriteString(args);                                       \
+    UCUNIT_WriteString(")");
+#endif
+
+/**
+ * @Macro:       UCSPEC_WriteSummary()
+ *
+ * @Description: Writes the the number of specs not iplemented,
+ *               then calls UCUNIT_WriteSummary to write the
+ *               remainder of the test suite summary.
+ *
+ * @Remarks:     This macro uses UCUNIT_WriteString(msg) and
+ *               UCUNIT_WriteInt(n) to write the summary.
+ *
+ */
+#define UCSPEC_WriteSummary()                                       \
+{                                                                   \
+    UCUNIT_WriteString("\n**************************************"); \
+    UCUNIT_WriteString("\nSpecs not implemented: ");                \
+    UCUNIT_WriteInt(ucspec_testcases_todo);                         \
+    UCUNIT_WriteSummary();                                          \
+}
+
+#endif /*UCSPEC_H_*/

--- a/v1.0.1/uCUnit-v1.0.h
+++ b/v1.0.1/uCUnit-v1.0.h
@@ -150,7 +150,7 @@
  * UCUNIT_MODE_VERBOSE: Passed and failed checks are displayed
  */
 //#define UCUNIT_MODE_NORMAL
-#define UCUNIT_MODE_VERBOSE
+//#define UCUNIT_MODE_VERBOSE
 
 /**
  * Max. number of checkpoints. This may depend on your application


### PR DESCRIPTION
I was experimenting with ucunit and a more behavior-driven approach to testing. Here's the result, in the hope it might be useful.

By default, it needs to have UCUNIT_MODE_VERBOSE undefined, so I moved that to Testsuite.c.

Optionally, it can have UCUNIT_MODE_SILENT defined, which will suppress failure details. 

When used in this way, the test output very nicely documents the specifications that were thus tested.

It is also possible to add empty specifications (without test code). These will be flagged as NOT IMPLEMENTED.
